### PR TITLE
fix: handle missing board cells gracefully

### DIFF
--- a/tictactoe.js
+++ b/tictactoe.js
@@ -40,9 +40,12 @@ function updateStatus() {
 // Print board in browser
 function updateBox(index, value) {
   var box = document.getElementById("box" + (index + 1));
+  if (!box) return;
   box.innerHTML = value;
-  if (value == "O") {
+  if (value === "O") {
     box.classList.add("text-yellow-500");
+  } else {
+    box.classList.remove("text-yellow-500");
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent crashes if a board cell is missing
- ensure board cell color class resets when clearing values

## Testing
- `node --check tictactoe.js`


------
https://chatgpt.com/codex/tasks/task_e_68abe045ad7c8322b66be4150c628614